### PR TITLE
Improvement suggestions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,13 +56,9 @@ fn main() -> IOResult<()> {
     let root_entries = std::fs::read_dir(src_path)?
         .filter_map(|entry_res| match entry_res {
             Ok(entry) => {
-                let bypass_filters = !filters.contains(&entry.file_name().into_string().unwrap());
-                bypass_filters.then(|| {
-                    Ok(RootEntry::new(
-                        entry.file_name().into_string().unwrap(),
-                        entry.path(),
-                    ))
-                })
+                let file_name = entry.file_name().into_string().ok()?;
+                let bypass_filters = !filters.contains(&file_name);
+                bypass_filters.then(|| Ok(RootEntry::new(file_name, entry.path())))
             }
             Err(e) => Some(Err(e)),
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,12 +120,12 @@ where
         for pattern in PATTERNS.iter() {
             let matcher = format!(
                 "{pattern}{filename}",
-                pattern = pattern.to_string(),
+                pattern = pattern,
                 filename = entry.file_name
             );
             let destination = format!(
                 "{pattern}{alias}/{filename}",
-                pattern = pattern.to_string(),
+                pattern = pattern,
                 alias = alias,
                 filename = entry.file_name
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,9 @@ fn inject<P>(path: P, alias: &str, root_entries: &[RootEntry]) -> IOResult<()>
 where
     P: AsRef<Path>,
 {
+    let mut content = std::fs::read_to_string(&path)?;
+
     for entry in root_entries {
-        let mut content = std::fs::read_to_string(&path)?;
         for pattern in PATTERNS.iter() {
             let matcher = format!(
                 "{pattern}{filename}",
@@ -123,9 +124,7 @@ where
             );
             content = content.replace(&matcher, &destination);
         }
-
-        std::fs::write(&path, content)?;
     }
 
-    Ok(())
+    std::fs::write(&path, content)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,7 @@ fn main() -> IOResult<()> {
 
     let filters = &args[2..];
 
-    let root_entries = std::fs::read_dir(&args[0])
-        .unwrap()
+    let root_entries = std::fs::read_dir(&args[0])?
         .filter_map(|d| {
             // storing given path root entries
             if d.is_ok() {
@@ -117,7 +116,7 @@ where
     P: AsRef<Path>,
 {
     for entry in root_entries {
-        let mut content = std::fs::read_to_string(&path).unwrap();
+        let mut content = std::fs::read_to_string(&path)?;
         for pattern in PATTERNS.iter() {
             let matcher = format!(
                 "{pattern}{filename}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ Usage ->
  - cargo run {path_to_src} {alias} [..filterable_dirs]
  - e.g cargo run ../myproject/src @app handlebars donottraverse public
 
-Running this script might prompt you to allow many files to be opened simultaneously -> 
-    In this case, run this beforehand : 
+Running this script might prompt you to allow many files to be opened simultaneously ->
+    In this case, run this beforehand :
 
 $ echo kern.maxfiles=65536 | sudo tee -a /etc/sysctl.conf
 $ echo kern.maxfilesperproc=65536 | sudo tee -a /etc/sysctl.conf
@@ -25,15 +25,18 @@ $ ulimit -n 12288
 
 *********/
 
-use std::{env::args, ffi::{OsStr, OsString}, path::{Path}};
-
+use std::{
+    env::args,
+    ffi::{OsStr, OsString},
+    path::Path,
+};
 
 const ALLOWED_EXTENSIONS: [&str; 4] = ["js", "jsx", "ts", "tsx"];
 const PATTERNS: [&str; 4] = ["from \"", "from '", "import \"", "import '"];
 
 struct RootEntry {
     file_name: String,
-    path: OsString
+    path: OsString,
 }
 
 impl RootEntry {
@@ -47,58 +50,93 @@ fn main() {
     let _args = args().skip(1);
     let args_length = _args.len();
 
-    if args_length < 2 { panic!("Insufficient number of arguments provided.") }
+    if args_length < 2 {
+        panic!("Insufficient number of arguments provided.")
+    }
 
     let mut args: Vec<String> = Vec::with_capacity(args_length);
     args.extend(_args);
 
     let filters = &args[2..];
 
-    let root_entries = std::fs::read_dir(&args[0]).unwrap().filter_map(|d| { // storing given path root entries
-        if d.is_ok() {
-             let dir_ok = d.ok().unwrap();
-             if !filters.contains(&dir_ok.file_name().into_string().unwrap()) { Some(RootEntry::new(dir_ok.file_name().into_string().unwrap(), dir_ok.path().into_os_string())) } 
-             else { None }
-        } else { None }
-    }).collect::<Vec<RootEntry>>();
+    let root_entries = std::fs::read_dir(&args[0])
+        .unwrap()
+        .filter_map(|d| {
+            // storing given path root entries
+            if d.is_ok() {
+                let dir_ok = d.ok().unwrap();
+                if !filters.contains(&dir_ok.file_name().into_string().unwrap()) {
+                    Some(RootEntry::new(
+                        dir_ok.file_name().into_string().unwrap(),
+                        dir_ok.path().into_os_string(),
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<RootEntry>>();
 
     for root_entry in &root_entries {
         read_dir_recursively(&root_entry.path, &args[1], &root_entries);
     }
- }
+}
 
 #[allow(unused_must_use)]
-fn read_dir_recursively<P>(path: P, alias: &String, root_entries: &Vec<RootEntry>) -> Result<(), std::io::Error>
+fn read_dir_recursively<P>(
+    path: P,
+    alias: &String,
+    root_entries: &Vec<RootEntry>,
+) -> Result<(), std::io::Error>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
-   let directories = std::fs::read_dir(path)?.filter_map(|d| d.ok()).collect::<Vec<_>>();
-     for d in directories {
-         let dir_metadata = d.metadata().unwrap();
-            if dir_metadata.is_dir() { read_dir_recursively(d.path(), alias, root_entries); } 
-            else if dir_metadata.is_file() {
-                let file_name = d.file_name();
-                let extension = Path::new(&file_name).extension().and_then(OsStr::to_str).unwrap(); 
-                if ALLOWED_EXTENSIONS.contains(&extension) { inject(d.path(), alias, root_entries);  }
+    let directories = std::fs::read_dir(path)?
+        .filter_map(|d| d.ok())
+        .collect::<Vec<_>>();
+    for d in directories {
+        let dir_metadata = d.metadata().unwrap();
+        if dir_metadata.is_dir() {
+            read_dir_recursively(d.path(), alias, root_entries);
+        } else if dir_metadata.is_file() {
+            let file_name = d.file_name();
+            let extension = Path::new(&file_name)
+                .extension()
+                .and_then(OsStr::to_str)
+                .unwrap();
+            if ALLOWED_EXTENSIONS.contains(&extension) {
+                inject(d.path(), alias, root_entries);
             }
-   }
+        }
+    }
 
     Ok(())
 }
 
 #[allow(unused_must_use)]
 fn inject<P>(path: P, alias: &String, root_entries: &Vec<RootEntry>) -> ()
-where 
+where
     P: AsRef<Path>,
-{   
+{
     for entry in root_entries {
         let mut content = std::fs::read_to_string(&path).unwrap();
         for pattern in PATTERNS.iter() {
-            let matcher = format!("{pattern}{filename}", pattern = pattern.to_string(), filename = entry.file_name);
-            let destination = format!("{pattern}{alias}/{filename}", pattern = pattern.to_string(), alias = alias, filename = entry.file_name);
+            let matcher = format!(
+                "{pattern}{filename}",
+                pattern = pattern.to_string(),
+                filename = entry.file_name
+            );
+            let destination = format!(
+                "{pattern}{alias}/{filename}",
+                pattern = pattern.to_string(),
+                alias = alias,
+                filename = entry.file_name
+            );
             content = content.replace(&matcher, &destination);
         }
-       
+
         std::fs::write(&path, content);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,18 +25,22 @@ $ ulimit -n 12288
 
 *********/
 
-use std::{env::args, ffi::OsString, io::Result as IOResult, path::Path};
+use std::{
+    env::args,
+    io::Result as IOResult,
+    path::{Path, PathBuf},
+};
 
 const ALLOWED_EXTENSIONS: [&str; 4] = ["js", "jsx", "ts", "tsx"];
 const PATTERNS: [&str; 4] = ["from \"", "from '", "import \"", "import '"];
 
 struct RootEntry {
     file_name: String,
-    path: OsString,
+    path: PathBuf,
 }
 
 impl RootEntry {
-    fn new(file_name: String, path: OsString) -> RootEntry {
+    fn new(file_name: String, path: PathBuf) -> RootEntry {
         RootEntry { file_name, path }
     }
 }
@@ -56,7 +60,7 @@ fn main() -> IOResult<()> {
                 bypass_filters.then(|| {
                     Ok(RootEntry::new(
                         entry.file_name().into_string().unwrap(),
-                        entry.path().into_os_string(),
+                        entry.path(),
                     ))
                 })
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,8 @@ fn main() {
 #[allow(unused_must_use)]
 fn read_dir_recursively<P>(
     path: P,
-    alias: &String,
-    root_entries: &Vec<RootEntry>,
+    alias: &str,
+    root_entries: &[RootEntry],
 ) -> Result<(), std::io::Error>
 where
     P: AsRef<Path>,
@@ -116,7 +116,7 @@ where
 }
 
 #[allow(unused_must_use)]
-fn inject<P>(path: P, alias: &String, root_entries: &Vec<RootEntry>) -> ()
+fn inject<P>(path: P, alias: &str, root_entries: &[RootEntry])
 where
     P: AsRef<Path>,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,19 +47,14 @@ impl RootEntry {
 }
 
 fn main() -> IOResult<()> {
-    let _args = args().skip(1);
-    let args_length = _args.len();
+    let args: Vec<_> = args().skip(1).collect();
 
-    if args_length < 2 {
-        panic!("Insufficient number of arguments provided.")
-    }
+    let (src_path, alias, filters) = match args.as_slice() {
+        [src_path, alias, filters @ ..] => (src_path, alias, filters),
+        _ => panic!("Insufficient number of arguments provided."),
+    };
 
-    let mut args: Vec<String> = Vec::with_capacity(args_length);
-    args.extend(_args);
-
-    let filters = &args[2..];
-
-    let root_entries = std::fs::read_dir(&args[0])?
+    let root_entries = std::fs::read_dir(src_path)?
         .filter_map(|d| {
             // storing given path root entries
             if d.is_ok() {
@@ -79,7 +74,7 @@ fn main() -> IOResult<()> {
         .collect::<Vec<RootEntry>>();
 
     for root_entry in &root_entries {
-        read_dir_recursively(&root_entry.path, &args[1], &root_entries)?;
+        read_dir_recursively(&root_entry.path, alias, &root_entries)?;
     }
 
     Ok(())


### PR DESCRIPTION
Key takeaways:
 - use [`clippy`](https://github.com/rust-lang/rust-clippy) (via `cargo clippy` or IDE integration)
 - format the code using [`rustfmt`](https://github.com/rust-lang/rustfmt) (via `cargo fmt` or IDE integration)
 - no need to open and write to the same file multiple times in a loop
 - basic argument parsing can be expressed simply with pattern matching (if you're looking to make a more advanced CLI, take a look at [`clap`](https://docs.rs/clap/2.33.3/clap/) or even [`structopt`](https://docs.rs/structopt/0.3.21/structopt/))
 - it's a good idea to bubble up IO errors instead of `unwrap`ing/ignoring them inside deeply nested logic